### PR TITLE
[Sikkerhet] Oppretter sikkerhetsfiler description.yaml og catalog-info.yaml og setter security champion i CODEOWNER

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/.security/ @cmalmqui

--- a/.security/description.yaml
+++ b/.security/description.yaml
@@ -1,4 +1,4 @@
-organization: RoS
-product: ALBBestPracticeManual
+organization: Sjø
+product: PRODSPEC
 repo_types: [Documentation]
-platforms: []
+platforms: [LOKALT]

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,11 @@
+# nonk8s
+apiVersion: "backstage.io/v1alpha1"
+kind: "Component"
+metadata:
+  name: "ALB_Best_Practice_Manual"
+  tags:
+  - "public"
+spec:
+  type: "documentation"
+  lifecycle: "production"
+  owner: "sj"


### PR DESCRIPTION
Denne PRen setter security champion i git-repoet ved å legge til `@cmalmqui` i CODEOWNER-filen.
Videre opprettes description-filen under .security-mappen med følgende felter:

- `organization: Sjø`
- `product: PRODSPEC`
- `repo_types: [Documentation]`
- `platforms: [LOKALT]`

Oppretter også `catalog-info.yaml` hvis den ikke finnes fra før. Dette gjør at repoet kan legges inn inn i utviklerportalen [kartverket.dev](https://kartverket.dev/).

Det er beskrevet [her i Sikkerhetshåndboka](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/732397586/Sikkerhet+i+repoet) hvorfor vi gjør dette.